### PR TITLE
fix: instantly finishing spinner not rendered

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -185,13 +185,12 @@ impl MultiSpinnerHandle {
             return;
         };
         let visible = self.last_visible_count.load(Ordering::Relaxed);
-        if visible == 0 {
-            return;
-        }
         let Ok(mut w) = self.writer.lock() else {
             return;
         };
-        let _ = write!(w, "\x1b[{visible}A");
+        if visible != 0 {
+            let _ = write!(w, "\x1b[{visible}A");
+        }
         let mut final_visible: usize = 0;
         for line in &snapshot {
             match &line.status {

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1861,6 +1861,21 @@ mod tests {
     }
 
     #[test]
+    fn test_instant_finish() {
+        let (writer, _buf_stop) = TestWriter::new();
+        let reader = writer.clone();
+        {
+            let multi = MultiSpinner::with_writer_tty(writer, true).start();
+            let spinner = multi.add("start");
+            spinner.success_with("end");
+        }
+        let end_line = format!("\r{CLEAR_LINE}{GREEN}✔{RESET} end\n");
+        let out = reader.output();
+        assert!(out.ends_with(&end_line));
+    }
+
+
+    #[test]
     fn test_multi_spinner_tty_warn_info_all() {
         let (writer, _buf) = TestWriter::new();
         let reader = writer.clone();

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -524,6 +524,17 @@ mod tests {
     }
 
     #[test]
+    fn test_instant_finish() {
+        let (writer, _buf_stop) = TestWriter::new();
+        let reader = writer.clone();
+        let spinner = Spinner::with_writer_tty("started", writer, true).start();
+        spinner.success_with("end");
+        let end_line = format_finalize("✔", GREEN, "end");
+        let out = reader.output();
+        assert!(out.ends_with(&end_line));
+    }
+
+    #[test]
     fn test_tty_mode_emits_ansi_codes() {
         let (writer, _buf) = TestWriter::new();
         let reader = writer.clone();


### PR DESCRIPTION
I noticed that sometimes very short running tasks don't leave a spinner message when using multi spinner. The problem is that the render thread does not always start before the spinner is finalized. This fix should prevent that behaviour. I also added tests to prevent regressions